### PR TITLE
support PIL installation with easy_install where we have no PIL subdirectory

### DIFF
--- a/hubarcode/code128/renderer.py
+++ b/hubarcode/code128/renderer.py
@@ -1,6 +1,11 @@
 """Rendering code for code128 barcode"""
 from cStringIO import StringIO
-from PIL import Image, ImageFont, ImageDraw
+try:
+    from PIL import Image, ImageFont, ImageDraw
+except ImportError:
+    import Image
+    import ImageFont
+    import ImageDraw
 import logging
 import os
 

--- a/hubarcode/datamatrix/renderer.py
+++ b/hubarcode/datamatrix/renderer.py
@@ -3,7 +3,10 @@
 __revision__ = "$Rev$"
 
 from cStringIO import StringIO
-from PIL import Image
+try:
+    from PIL import Image
+except ImportError:
+    import Image
 
 
 class DataMatrixRenderer:

--- a/hubarcode/ean13/renderer.py
+++ b/hubarcode/ean13/renderer.py
@@ -1,7 +1,12 @@
 """Rendering code for EAN-13 barcode"""
 
 import os
-from PIL import Image, ImageFont, ImageDraw
+try:
+    from PIL import Image, ImageFont, ImageDraw
+except ImportError:
+    import Image
+    import ImageFont
+    import ImageDraw
 # handling movement of reduce to functools python >= 2.6
 try:
     from functools import reduce

--- a/hubarcode/qrcode/renderer.py
+++ b/hubarcode/qrcode/renderer.py
@@ -1,7 +1,10 @@
 """QR Code renderer"""
 
 from cStringIO import StringIO
-from PIL import Image
+try:
+    from PIL import Image
+except ImportError:
+    import Image
 
 
 class QRCodeRenderer:


### PR DESCRIPTION
This is a fixup of the regression introduced by e693d6cf (#16).

If PIL is installed with easy_install, there is no PIL subdirectory, thus we should import like "import Image". But if PIL is installed without easy_install, there is a PIL subdirectory, thus we should import like "from PIL import Image".

This pull request will support both cases.

Please see https://mail.python.org/pipermail/image-sig/2010-August/006480.html for the detail of the issue.
